### PR TITLE
9-marketoverview-is-missing

### DIFF
--- a/vue-tradingview-widgets/package.json
+++ b/vue-tradingview-widgets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-tradingview-widgets",
-  "version": "1.0.2",
+  "version": "1.1.2",
   "description": "tradingview widgets for Vue3 and Nuxt3",
   "author": "Ehsan Shahvirdi",
   "license": "MIT",

--- a/vue-tradingview-widgets/src/lib-components/index.ts
+++ b/vue-tradingview-widgets/src/lib-components/index.ts
@@ -16,3 +16,4 @@ export { default as SymbolOverview } from './SymbolOverview.vue';
 export { default as TechnicalAnalysis } from './TechnicalAnalysis.vue';
 export { default as Ticker } from './Ticker.vue';
 export { default as TickerTape } from './TickerTape.vue';
+export { default as MarketOverview } from './MarketOverview.vue';

--- a/vue-tradingview-widgets/src/lib-components/index.ts
+++ b/vue-tradingview-widgets/src/lib-components/index.ts
@@ -17,3 +17,4 @@ export { default as TechnicalAnalysis } from './TechnicalAnalysis.vue';
 export { default as Ticker } from './Ticker.vue';
 export { default as TickerTape } from './TickerTape.vue';
 export { default as MarketOverview } from './MarketOverview.vue';
+export { default as SymbolInfo } from './MarketOverview.vue';


### PR DESCRIPTION
#9 fix marketoverview-is-missing and add SymbolInfo and published v1.1.2